### PR TITLE
Fix string representation of ContractingDecimal

### DIFF
--- a/contracting/stdlib/bridge/decimal.py
+++ b/contracting/stdlib/bridge/decimal.py
@@ -113,6 +113,9 @@ class ContractingDecimal:
     def __str__(self):
         return self._d.__str__()
 
+    def __repr__(self):
+      return self._d.__str__()
+
     def __neg__(self):
         return self._d.__neg__()
 


### PR DESCRIPTION
Before:
```
xian_abci > 2024-02-10 16:12:25,561 - DEBUG - {'balance': <contracting.stdlib.bridge.decimal.ContractingDecimal object at 0x7faaaa0e9a50>, 'stamp_cost': 20, 'stamps': 100}
```

After:
```
xian_abci > 2024-02-10 16:03:37,089 - DEBUG - {'balance': 90444149.27820000, 'stamp_cost': 20, 'stamps': 100}
```

This is not only helpful in the logs but also when a ContractingDecimal is returned in a contract